### PR TITLE
🔧  Change submodule config and 📝 add note about wheels

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -5,7 +5,7 @@
 	shallow = true
 [submodule "extern/json"]
 	path = extern/json
-	url = git@github.com:nlohmann/json.git
+	url = https://github.com/nlohmann/json.git
 	branch = develop
 	shallow = true
 [submodule "extern/pybind11"]

--- a/README.md
+++ b/README.md
@@ -38,6 +38,11 @@ MQT QECC is developed as a C++ library with an easy to use Python interface.
     pip install  mqt.qecc --no-binary mqt.qecc
     ```
   This enables platform specific compiler optimizations that cannot be enabled on portable wheels.
+
+> **Note**
+> Pre-built wheels are not yet available. They will be released soon. In the meantime, follow the instructions below for cloning the repository
+> and call `pip install --editable .` in the cloned directory to install the Python package.
+
 - Once installed, start using it in Python:
   ```python
   from mqt.qecc import *


### PR DESCRIPTION
This PR changes the submodule configuration for the `json` submodule from using SSH to https. This should allow people with no valid SSH key setup to properly clone the repository.

Furthermore it adds a note stating that the pre-built wheels are not yet published and how to work with the package in the meantime.

Resolves #1 